### PR TITLE
Implemented --just-rename and --in-place options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@ Options:
   -P, --no-prettier            do not run prettier on converted code
   --no-allow-js                convert all JS files to TypeScript(including without Flow)
   --no-remove                  keep js files after appropriate ts files were created
+  --just-rename                just rename the files; don't convert them
+  --in-place                   convert files in place without renaming them
   -i, --include <includeGlob>  Glob expression of files to include, default: "**/*.{js,mjs,jsx,js.flow}" (default: "**/*.{js,mjs,jsx,js.flow}")
   -x, --exclude <excludeGlob>  Additional excludes glob expression (by default node_modules and files from .gitignore is excluded) (default: "**/node_modules/**")
   -h, --help                   output usage information

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,8 @@ export interface Options {
   readonly remove: boolean;
   readonly include: string;
   readonly exclude: string;
+  readonly justRename: boolean;
+  readonly inPlace: boolean;
 }
 
 const program = new commander.Command();
@@ -25,6 +27,16 @@ program
   .description('Flow to TypeScript migration tool')
   .option('-R, --no-recast', 'use babel generator instead of recast', false)
   .option('-P, --no-prettier', 'do not run prettier on converted code', false)
+  .option(
+    '-j, --just-rename',
+    "just rename the files; don't convert them",
+    false
+  )
+  .option(
+    '-i, --in-place',
+    'convert files in place without renaming them',
+    false
+  )
   .usage('[options] ./path/to/project')
   .option(
     '--no-allow-js',
@@ -58,6 +70,20 @@ if (args.length === 0) {
 if (args.length > 1) {
   console.error('Only one project root can be specified');
   process.exit(1);
+}
+
+if (opts.inPlace && opts.justRename) {
+  console.error("Can't use --in-place and --just-rename together");
+  process.exit(1);
+}
+if (!opts.remove && opts.inPlace) {
+  console.warn('--no-remove does nothing when --in-place is set');
+}
+if (!opts.remove && opts.justRename) {
+  console.warn('--no-remove does nothing when --just-rename is set');
+}
+if (!opts.recast && opts.justRename) {
+  console.warn('--no-recast does nothing when --just-rename is set');
 }
 
 convert(args[0], opts).then(

--- a/src/detectOptions.ts
+++ b/src/detectOptions.ts
@@ -17,7 +17,7 @@ export function detectOptions(source: string, filename: string): SourceOptions {
     filename,
   });
 
-  let isJSX = /\.jsx$/i.test(filename);
+  let isJSX = /\.(jsx|tsx)$/i.test(filename);
   let isFlow = /@flow/.test(source) || /\.js\.flow$/i.test(filename);
 
   if (flowAst === null) {


### PR DESCRIPTION
Splitting the process into two steps allows you to commit your git repository in between, ensuring it tracks all the renames.  It also makes it easy to review the changes the converted made.  I discovered and filed a lot of issues by using this technique on a large code base.